### PR TITLE
Update codebase for i18n utility calls; See: websharks/comment-mail#72

### DIFF
--- a/comment-mail-pro/includes/classes/menu-page-queue-event-log-table.php
+++ b/comment-mail-pro/includes/classes/menu-page-queue-event-log-table.php
@@ -191,8 +191,8 @@ namespace comment_mail // Root namespace.
 				$plugin = plugin(); // Needed for translations.
 
 				return array(
-					'event::invalidated' => $plugin->utils_i18n->event_label('invalidated'),
-					'event::notified'    => $plugin->utils_i18n->event_label('notified'),
+					'event::invalidated' => $plugin->utils_i18n->event_label('invalidated', 'ucwords'),
+					'event::notified'    => $plugin->utils_i18n->event_label('notified', 'ucwords'),
 				);
 			}
 

--- a/comment-mail-pro/includes/classes/menu-page-sub-event-log-table.php
+++ b/comment-mail-pro/includes/classes/menu-page-sub-event-log-table.php
@@ -235,12 +235,12 @@ namespace comment_mail // Root namespace.
 				$plugin = plugin(); // Needed for translations.
 
 				return array(
-					'event::inserted'    => $plugin->utils_i18n->event_label('inserted'),
-					'event::updated'     => $plugin->utils_i18n->event_label('updated'),
-					'event::overwritten' => $plugin->utils_i18n->event_label('overwritten'),
-					'event::purged'      => $plugin->utils_i18n->event_label('purged'),
-					'event::cleaned'     => $plugin->utils_i18n->event_label('cleaned'),
-					'event::deleted'     => $plugin->utils_i18n->event_label('deleted'),
+					'event::inserted'    => $plugin->utils_i18n->event_label('inserted', 'ucwords'),
+					'event::updated'     => $plugin->utils_i18n->event_label('updated', 'ucwords'),
+					'event::overwritten' => $plugin->utils_i18n->event_label('overwritten', 'ucwords'),
+					'event::purged'      => $plugin->utils_i18n->event_label('purged', 'ucwords'),
+					'event::cleaned'     => $plugin->utils_i18n->event_label('cleaned', 'ucwords'),
+					'event::deleted'     => $plugin->utils_i18n->event_label('deleted', 'ucwords'),
 				);
 			}
 

--- a/comment-mail-pro/includes/classes/menu-page-subs-table.php
+++ b/comment-mail-pro/includes/classes/menu-page-subs-table.php
@@ -197,10 +197,10 @@ namespace comment_mail // Root namespace.
 				$plugin = plugin(); // Needed for translations.
 
 				return array(
-					'status::unconfirmed' => $plugin->utils_i18n->status_label('unconfirmed'),
-					'status::subscribed'  => $plugin->utils_i18n->status_label('subscribed'),
-					'status::suspended'   => $plugin->utils_i18n->status_label('suspended'),
-					'status::trashed'     => $plugin->utils_i18n->status_label('trashed'),
+					'status::unconfirmed' => $plugin->utils_i18n->status_label('unconfirmed', 'ucwords'),
+					'status::subscribed'  => $plugin->utils_i18n->status_label('subscribed', 'ucwords'),
+					'status::suspended'   => $plugin->utils_i18n->status_label('suspended', 'ucwords'),
+					'status::trashed'     => $plugin->utils_i18n->status_label('trashed', 'ucwords'),
 				);
 			}
 

--- a/comment-mail-pro/includes/classes/menu-page-table-base.php
+++ b/comment-mail-pro/includes/classes/menu-page-table-base.php
@@ -611,7 +611,7 @@ namespace comment_mail // Root namespace.
 				$post_title_clip        = $this->plugin->utils_string->mid_clip($item->{$prefix.'title'});
 				$post_date              = $this->plugin->utils_date->i18n('M j, Y', strtotime($item->{$prefix.'date_gmt'}));
 				$post_date_ago          = $this->plugin->utils_date->approx_time_difference(strtotime($item->{$prefix.'date_gmt'}));
-				$post_comments_status   = $this->plugin->utils_i18n->status_label($this->plugin->utils_db->post_comment_status__($item->{$prefix.'comment_status'}));
+				$post_comments_status   = $this->plugin->utils_i18n->status_label($this->plugin->utils_db->post_comment_status__($item->{$prefix.'comment_status', 'ucwords'}));
 				$post_edit_comments_url = $this->plugin->utils_url->post_edit_comments_short($item->{$key});
 				$post_total_subs        = $this->plugin->utils_sub->query_total($item->{$key});
 				$post_total_comments    = (integer)$item->{$prefix.'comment_count'};
@@ -678,7 +678,7 @@ namespace comment_mail // Root namespace.
 				);
 				$comment_date_time = $this->plugin->utils_date->i18n('M j, Y g:i a', strtotime($item->{$prefix.'date_gmt'}));
 				$comment_time_ago  = $this->plugin->utils_date->approx_time_difference(strtotime($item->{$prefix.'date_gmt'}));
-				$comment_status    = $this->plugin->utils_i18n->status_label($this->plugin->utils_db->comment_status__($item->{$prefix.'approved'}));
+				$comment_status    = $this->plugin->utils_i18n->status_label($this->plugin->utils_db->comment_status__($item->{$prefix.'approved', 'ucwords'}));
 
 				$comment_info = '<i class="fa fa-comment"></i>'. // Start w/ a comment bubble icon.
 				                ' '.$this->plugin->utils_markup->name_email($item->{$prefix.'author'}, $item->{$prefix.'author_email'}, $name_email_args);


### PR DESCRIPTION
Update codebase for i18n utility calls
- Update each of those i18n function calls, so that we pass the proper parameters that alter the caSe of labels presented in the UI for menu pages; by passing the `$transform` parameter as `ucwords`
- STEP 3: Use Proper Case for Statuses and Events on UI https://quire.io/w/8C4cVjc0O3g2ZXK3OnQUG9eJ/Update_Codebase_i.e....

See: websharks/comment-mail#72