### PR TITLE
Fix spelling mistake in email template; See: websharks/comment-mail#208

### DIFF
--- a/comment-mail-pro/includes/templates/type-a/email/sub-confirmation/message.php
+++ b/comment-mail-pro/includes/templates/type-a/email/sub-confirmation/message.php
@@ -80,13 +80,13 @@ $sub_last_update_time_ago = $plugin->utils_date->i18n_utc('M jS, Y @ g:i a T', $
 		<?php if($sub_comment): // Subscribing to a specific comment? ?>
 
 			<?php if($subscribed_to_own_comment): ?>
-				<?php echo sprintf(__('You are receiving this email because asked to be notified about replies to <a href="%1$s">your comment</a>; on:', $plugin->text_domain), esc_html($sub_comment_url)); ?>
+				<?php echo sprintf(__('You are receiving this email because you asked to be notified about replies to <a href="%1$s">your comment</a>; on:', $plugin->text_domain), esc_html($sub_comment_url)); ?>
 			<?php else: // The comment was not authored by this subscriber; i.e. it's not their own. ?>
-				<?php echo sprintf(__('You are receiving this email because asked to be notified about replies to <a href="%1$s">this comment</a>; on:', $plugin->text_domain), esc_html($sub_comment_url)); ?>
+				<?php echo sprintf(__('You are receiving this email because you asked to be notified about replies to <a href="%1$s">this comment</a>; on:', $plugin->text_domain), esc_html($sub_comment_url)); ?>
 			<?php endif; ?>
 
 		<?php else: // All comments/replies on this post. ?>
-			<?php echo __('You are receiving this email because asked to be notified about all comments/replies to:', $plugin->text_domain); ?>
+			<?php echo __('You are receiving this email because you asked to be notified about all comments/replies to:', $plugin->text_domain); ?>
 		<?php endif; ?>
 
 	</p>

--- a/comment-mail-pro/includes/templates/type-s/email/sub-confirmation/snippet/message.php
+++ b/comment-mail-pro/includes/templates/type-s/email/sub-confirmation/snippet/message.php
@@ -8,12 +8,12 @@
 
 	[if sub_comment]
 		[if subscribed_to_own_comment]
-			You are receiving this email because asked to be notified about replies to <a href="[sub_comment_url]">your comment</a>; on:
+			You are receiving this email because you asked to be notified about replies to <a href="[sub_comment_url]">your comment</a>; on:
 		[else]
-	        You are receiving this email because asked to be notified about replies to <a href="[sub_comment_url]">this comment</a>; on:
+	        You are receiving this email because you asked to be notified about replies to <a href="[sub_comment_url]">this comment</a>; on:
 		[endif]
 	[else]
-		You are receiving this email because asked to be notified about all comments/replies to:
+		You are receiving this email because you asked to be notified about all comments/replies to:
 	[endif]
 
 </p>

--- a/comment-mail-pro/includes/templates/type-s/email/sub-confirmation/snippet/message.php
+++ b/comment-mail-pro/includes/templates/type-s/email/sub-confirmation/snippet/message.php
@@ -10,7 +10,7 @@
 		[if subscribed_to_own_comment]
 			You are receiving this email because you asked to be notified about replies to <a href="[sub_comment_url]">your comment</a>; on:
 		[else]
-	        You are receiving this email because you asked to be notified about replies to <a href="[sub_comment_url]">this comment</a>; on:
+			You are receiving this email because you asked to be notified about replies to <a href="[sub_comment_url]">this comment</a>; on:
 		[endif]
 	[else]
 		You are receiving this email because you asked to be notified about all comments/replies to:

--- a/comment-mail-pro/includes/translations/comment-mail-pro.pot
+++ b/comment-mail-pro/includes/translations/comment-mail-pro.pot
@@ -4957,15 +4957,15 @@ msgid "your subscription."
 msgstr ""
 
 #: includes/templates/type-a/email/sub-confirmation/message.php:83
-msgid "You are receiving this email because asked to be notified about replies to <a href=\"%1$s\">your comment</a>; on:"
+msgid "You are receiving this email because you asked to be notified about replies to <a href=\"%1$s\">your comment</a>; on:"
 msgstr ""
 
 #: includes/templates/type-a/email/sub-confirmation/message.php:85
-msgid "You are receiving this email because asked to be notified about replies to <a href=\"%1$s\">this comment</a>; on:"
+msgid "You are receiving this email because you asked to be notified about replies to <a href=\"%1$s\">this comment</a>; on:"
 msgstr ""
 
 #: includes/templates/type-a/email/sub-confirmation/message.php:89
-msgid "You are receiving this email because asked to be notified about all comments/replies to:"
+msgid "You are receiving this email because you asked to be notified about all comments/replies to:"
 msgstr ""
 
 #: includes/templates/type-a/email/sub-confirmation/message.php:117


### PR DESCRIPTION
Fix spelling mistake in email template (simple and advanced) and translation file; 

- If selected, "yes, replies to my comment"
![screen shot 2016-01-22 at 5 53 41 pm](https://cloud.githubusercontent.com/assets/7514953/12507648/fe63b414-c131-11e5-9015-f0c7cb728dcd.png)


- If selected, "yes, all comments/replies"
![screen shot 2016-01-22 at 5 56 25 pm](https://cloud.githubusercontent.com/assets/7514953/12507654/17a1b552-c132-11e5-8b41-6a49a7c30038.png)

See: websharks/comment-mail#208