### PR TITLE
Pre-populate name/email fields on Add new subscription form; See: websharks/comment-mail#204

### DIFF
--- a/comment-mail-pro/includes/classes/sub-manage-sub-form-base.php
+++ b/comment-mail-pro/includes/classes/sub-manage-sub-form-base.php
@@ -294,8 +294,8 @@ namespace comment_mail // Root namespace.
 				            break;
 
 				        case 'email':
-				            if(!empty($current->email)) {
-				                return (string)$current->email;
+				            if(!empty($current->user_email)) {
+				                return (string)$current->user_email;
 				            }
 				            break;
 				    }

--- a/comment-mail-pro/includes/classes/sub-manage-sub-form-base.php
+++ b/comment-mail-pro/includes/classes/sub-manage-sub-form-base.php
@@ -289,7 +289,7 @@ namespace comment_mail // Root namespace.
 
 				        case 'lname':
 				            if(!empty($current->last_name)) {
-				                return $this->plugin->utils_string->last_name((string)$current->last_name);
+				                return $this->plugin->utils_string->last_name('- '.(string)$current->last_name);
 				            }
 				            break;
 
@@ -299,7 +299,7 @@ namespace comment_mail // Root namespace.
 				            }
 				            break;
 				    }
-				}						
+				}
 
 				return NULL; // Default value.
 			}

--- a/comment-mail-pro/includes/classes/sub-manage-sub-form-base.php
+++ b/comment-mail-pro/includes/classes/sub-manage-sub-form-base.php
@@ -252,6 +252,55 @@ namespace comment_mail // Root namespace.
 					if(!empty($current_email_latest_info->{$key_prop}))
 						return trim((string)$current_email_latest_info->{$key_prop});
 
+				if(!$this->is_edit && !static::$processing && in_array($key_prop, array('fname', 'lname', 'email'), TRUE)) {
+				    // We can try to autofill fname, lname, email for new subscriptions.
+				    $current = wp_get_current_commenter();
+
+				    switch($key_prop) {
+				        case 'fname':
+				            if(!empty($current['comment_author'])) {
+				                return $this->plugin->utils_string->first_name((string)$current['comment_author']);
+				            }
+				            break;
+
+				        case 'lname':
+				            if(!empty($current['comment_author'])) {
+				                return $this->plugin->utils_string->last_name((string)$current['comment_author']);
+				            }
+				            break;
+
+				        case 'email':
+				            if(!empty($current['comment_author_email'])) {
+				                return (string)$current['comment_author_email'];
+				            }
+				            break;
+				    }
+				}
+				if(!$this->is_edit && !static::$processing && in_array($key_prop, array('fname', 'lname', 'email'), TRUE)) {
+				    // We can try to autofill fname, lname, email for new subscriptions.
+				    $current = wp_get_current_user();
+
+				    switch($key_prop) {
+				        case 'fname':
+				            if(!empty($current->first_name)) {
+				                return $this->plugin->utils_string->first_name((string)$current->first_name);
+				            }
+				            break;
+
+				        case 'lname':
+				            if(!empty($current->last_name)) {
+				                return $this->plugin->utils_string->last_name((string)$current->last_name);
+				            }
+				            break;
+
+				        case 'email':
+				            if(!empty($current->email)) {
+				                return (string)$current->email;
+				            }
+				            break;
+				    }
+				}						
+
 				return NULL; // Default value.
 			}
 


### PR DESCRIPTION
Pre-populate name/email fields on Add new subscription form; 

![screen shot 2016-01-29 at 8 10 25 am](https://cloud.githubusercontent.com/assets/7514953/12664128/4530f51a-c668-11e5-9683-5ed1a9efc56e.png)

See: websharks/comment-mail#204