### PR TITLE
Update Stat Log Endpoint URL; See: websharks/comment-mail#221

### DIFF
--- a/comment-mail-pro/includes/classes/stats-pinger.php
+++ b/comment-mail-pro/includes/classes/stats-pinger.php
@@ -47,7 +47,7 @@ namespace comment_mail
 
 				$this->plugin->options_quick_save(array('last_pro_stats_log' => (string)time()));
 
-				$stats_api_url      = 'https://www.websharks-inc.com/products/stats-log.php';
+				$stats_api_url      = 'https://stats.wpsharks.io/log';
 				$stats_api_url_args = array(
 					'os'              => PHP_OS,
 					'php_version'     => PHP_VERSION,


### PR DESCRIPTION
Update Stat Log Endpoint URL; 

- Endpoint URL updated to `https://stats.wpsharks.io/log`

See: websharks/comment-mail#221