### PR TITLE
Replace with false return value; See: websharks/comment-mail#260

### DIFF
--- a/src/includes/classes/Installer.php
+++ b/src/includes/classes/Installer.php
@@ -53,7 +53,7 @@ class Installer extends AbsBase
                 $_sql = str_replace('%%prefix%%', $this->plugin->utils_db->prefix(), $_sql);
                 $_sql = $this->plugin->utils_db->fulltextCompat($_sql);
 
-                if (!$this->plugin->utils_db->wp->query($_sql)) { // Table creation failure?
+                if ($this->plugin->utils_db->wp->query($_sql) === false) { // Table creation failure?
                     throw new \exception(sprintf(__('DB table creation failure. Table: `%1$s`. SQL: `%2$s`.', SLUG_TD), $_sql_file_table, $_sql));
                 }
             }

--- a/src/includes/classes/QueueInjector.php
+++ b/src/includes/classes/QueueInjector.php
@@ -76,7 +76,7 @@ class QueueInjector extends AbsBase
 
         $sql = $this->plugin->utils_string->trim($sql, '', ','); // Trim leftover delimiter.
 
-        if ($this->plugin->utils_db->wp->query($sql) === false) { // Insert failure?
+        if (!$this->plugin->utils_db->wp->query($sql)) { // Insert failure?
             throw new \exception(__('Insertion failure.', SLUG_TD));
         }
     }

--- a/src/includes/classes/QueueInjector.php
+++ b/src/includes/classes/QueueInjector.php
@@ -76,7 +76,7 @@ class QueueInjector extends AbsBase
 
         $sql = $this->plugin->utils_string->trim($sql, '', ','); // Trim leftover delimiter.
 
-        if (!$this->plugin->utils_db->wp->query($sql)) { // Insert failure?
+        if ($this->plugin->utils_db->wp->query($sql) === false) { // Insert failure?
             throw new \exception(__('Insertion failure.', SLUG_TD));
         }
     }

--- a/src/includes/classes/QueueProcessor.php
+++ b/src/includes/classes/QueueProcessor.php
@@ -678,7 +678,7 @@ class QueueProcessor extends AbsBase
 
                " WHERE `ID` = '".esc_sql($entry_props->entry->ID)."'";
 
-        if (!$this->plugin->utils_db->wp->query($sql)) {
+        if ($this->plugin->utils_db->wp->query($sql) === false) {
             throw new \exception(__('Update failure.', SLUG_TD));
         }
         $entry_props->entry->hold_until_time = $entry_hold_until_time;


### PR DESCRIPTION
Replace with false return value; 

- Search codebase for `!$this->plugin->utils_db->wp->query` and replace with false return value. 

> In most cases, we should be looking for a false return value, because a 0 return value will be falsy too, and yet not actually a failure. We need to look for false (boolean) explicitly to avoid this sort of problem.

See: websharks/comment-mail#260