### PR TITLE
Feature/285

### DIFF
--- a/.build.props
+++ b/.build.props
@@ -3,14 +3,13 @@ project_owner                                           = websharks
 project_slug                                            = comment-mail-pro
 project_namespace                                       = WebSharks\\CommentMail\\Pro
 project_sub_namespace                                   = CommentMailPro
-project_other_phar_fileset_exclusions                   = README.md
-project_other_zip_tgz_fileset_exclusions                = README.md
+project_other_zip_tgz_fileset_exclusions                = README.md,src/vendor/erusev/parsedown*/test/**,src/vendor/lusitanian/oauth/examples/**
 
 project_lite_title                                      = Comment Mail
 project_lite_slug                                       = comment-mail
 project_lite_namespace                                  = WebSharks\\CommentMail
 project_lite_sub_namespace                              = CommentMail
-project_lite_other_zip_tgz_fileset_exclusions           = README.md,**/templates/type-a/**
+project_lite_other_zip_tgz_fileset_exclusions           = README.md,src/vendor/erusev/parsedown*/test/**,**/templates/type-a/**,src/vendor/lusitanian/**,src/vendor/mailchimp/**
 project_lite_text_domain_regex_replacement_pattern      = SLUG_TD
 
 project_version                                         = %y%m%d

--- a/src/includes/classes/UtilsRve.php
+++ b/src/includes/classes/UtilsRve.php
@@ -1,4 +1,5 @@
 <?php
+/*[pro exclude-file-from="lite"]*/
 /**
  * RVE Utilities.
  *


### PR DESCRIPTION
Added the following exclusions to the `.build.props` file:

### Lite

- `src/vendor/erusev/parsedown*/test/**`
- `src/vendor/lusitanian/**`
- `src/vendor/mailchimp/**`

### Pro

- `src/vendor/erusev/parsedown*/test/**`
- `src/vendor/lusitanian/oauth/examples/**`

Also excluded `src/includes/classes/UtilsRve.php` from the Lite build.

https://github.com/websharks/comment-mail/issues/285