### PR TITLE
Disable back button when no subscriptions are available; See: websharks/comment-mail#229

### DIFF
--- a/src/includes/classes/SubManageSubFormBase.php
+++ b/src/includes/classes/SubManageSubFormBase.php
@@ -159,6 +159,8 @@ class SubManageSubFormBase extends AbsBase
         $sub_key = $this->sub_key;
         $is_edit = $this->is_edit;
         $sub     = $this->sub;
+        $current_email     = (boolean)$this->plugin->utils_sub->currentEmail();
+        $has_subscriptions = $current_email ? (boolean)$this->plugin->utils_sub->queryTotal(null, ['sub_email' => $current_email, 'status' => 'subscribed', 'sub_email_or_user_ids' => true]) : false;
 
         $form_fields = $this->form_fields;
 

--- a/src/includes/classes/SubManageSubFormBase.php
+++ b/src/includes/classes/SubManageSubFormBase.php
@@ -159,8 +159,8 @@ class SubManageSubFormBase extends AbsBase
         $sub_key = $this->sub_key;
         $is_edit = $this->is_edit;
         $sub     = $this->sub;
-        $current_email     = (boolean)$this->plugin->utils_sub->currentEmail();
-        $has_subscriptions = $current_email ? (boolean)$this->plugin->utils_sub->queryTotal(null, ['sub_email' => $current_email, 'status' => 'subscribed', 'sub_email_or_user_ids' => true]) : false;
+        $current_email     = $this->plugin->utils_sub->currentEmail();
+        $has_subscriptions = (boolean)$current_email ? (boolean)$this->plugin->utils_sub->queryTotal(null, ['sub_email' => $current_email, 'status' => 'subscribed', 'sub_email_or_user_ids' => true]) : false;
 
         $form_fields = $this->form_fields;
 

--- a/src/includes/templates/type-a/site/footer-tag.php
+++ b/src/includes/templates/type-a/site/footer-tag.php
@@ -31,8 +31,8 @@ $home_url = home_url('/'); // Multisite compatible.
 $blog_name_clip = $plugin->utils_string->clip(get_bloginfo('name'));
 
 // Summary return URL; w/ all summary navigation vars preserved.
-$current_email     = (boolean)$this->plugin->utils_sub->currentEmail();
-$has_subscriptions = $current_email ? (boolean)$this->plugin->utils_sub->queryTotal(null, ['sub_email' => $current_email, 'status' => 'subscribed', 'sub_email_or_user_ids' => true]) : false;
+$current_email     = $this->plugin->utils_sub->currentEmail();
+$has_subscriptions = (boolean)$current_email ? (boolean)$this->plugin->utils_sub->queryTotal(null, ['sub_email' => $current_email, 'status' => 'subscribed', 'sub_email_or_user_ids' => true]) : false;
 $sub_summary_return_url = $has_subscriptions && $plugin->utils_url->subManageSummaryUrl(!empty($sub_key) ? $sub_key : '', null, true);
 
 // Current `host[/path]` with support for multisite network child blogs.

--- a/src/includes/templates/type-a/site/footer-tag.php
+++ b/src/includes/templates/type-a/site/footer-tag.php
@@ -31,7 +31,9 @@ $home_url = home_url('/'); // Multisite compatible.
 $blog_name_clip = $plugin->utils_string->clip(get_bloginfo('name'));
 
 // Summary return URL; w/ all summary navigation vars preserved.
-$sub_summary_return_url = $plugin->utils_url->subManageSummaryUrl(!empty($sub_key) ? $sub_key : '', null, true);
+$current_email     = (boolean)$this->plugin->utils_sub->currentEmail();
+$has_subscriptions = $current_email ? (boolean)$this->plugin->utils_sub->queryTotal(null, ['sub_email' => $current_email, 'status' => 'subscribed', 'sub_email_or_user_ids' => true]) : false;
+$sub_summary_return_url = $has_subscriptions && $plugin->utils_url->subManageSummaryUrl(!empty($sub_key) ? $sub_key : '', null, true);
 
 // Current `host[/path]` with support for multisite network child blogs.
 $current_host_path = $plugin->utils_url->currentHostPath();

--- a/src/includes/templates/type-a/site/footer-tag.php
+++ b/src/includes/templates/type-a/site/footer-tag.php
@@ -31,9 +31,9 @@ $home_url = home_url('/'); // Multisite compatible.
 $blog_name_clip = $plugin->utils_string->clip(get_bloginfo('name'));
 
 // Summary return URL; w/ all summary navigation vars preserved.
-$current_email     = $this->plugin->utils_sub->currentEmail();
-$has_subscriptions = (boolean)$current_email ? (boolean)$this->plugin->utils_sub->queryTotal(null, ['sub_email' => $current_email, 'status' => 'subscribed', 'sub_email_or_user_ids' => true]) : false;
-$sub_summary_return_url = $has_subscriptions && $plugin->utils_url->subManageSummaryUrl(!empty($sub_key) ? $sub_key : '', null, true);
+$current_email          = $this->plugin->utils_sub->currentEmail();
+$has_subscriptions      = (boolean) $current_email ? (boolean) $this->plugin->utils_sub->queryTotal(null, ['sub_email' => $current_email, 'status' => 'subscribed', 'sub_email_or_user_ids' => true]) : false;
+$sub_summary_return_url = $has_subscriptions ? $plugin->utils_url->subManageSummaryUrl(!empty($sub_key) ? $sub_key : '', null, true) : false;
 
 // Current `host[/path]` with support for multisite network child blogs.
 $current_host_path = $plugin->utils_url->currentHostPath();

--- a/src/includes/templates/type-a/site/sub-actions/manage-sub-form.php
+++ b/src/includes/templates/type-a/site/sub-actions/manage-sub-form.php
@@ -79,11 +79,13 @@ echo str_replace('%%title%%', $is_edit ? __('Edit Subscription', SLUG_TD)
                         </li>
                     <?php endforeach; ?>
                 </ul>
-                <p style="margin-top:1em;">
-                    <a href="<?php echo esc_attr($plugin->utils_url->subManageSummaryUrl($sub_key, null, true)); ?>">
-                        <i class="fa fa-arrow-circle-left"></i> <?php echo __('Back to My Subscriptions', SLUG_TD); ?>
-                    </a>
-                </p>
+                    <p style="margin-top:1em;">
+                        <?php if ($is_edit || ($current_email && $has_subscriptions)) : ?>
+                            <a href="<?php echo esc_attr($plugin->utils_url->subManageSummaryUrl($sub_key, null, true)); ?>">
+                                <i class="fa fa-arrow-circle-left"></i> <?php echo __('Back to My Subscriptions', SLUG_TD); ?>
+                            </a>
+                        <?php endif; ?>
+                    </p>
             </div>
 
         <?php elseif ($error_codes) : // Any other major errors? ?>
@@ -163,19 +165,23 @@ echo str_replace('%%title%%', $is_edit ? __('Edit Subscription', SLUG_TD)
                             </li>
                         <?php endforeach; ?>
                     </ul>
-                    <p style="margin-top:1em;">
-                        <a href="<?php echo esc_attr($sub_summary_return_url); ?>">
-                            <i class="fa fa-arrow-circle-left"></i> <?php echo __('Back to My Subscriptions', SLUG_TD); ?>
-                        </a>
-                    </p>
+                        <p style="margin-top:1em;">
+                            <?php if ($is_edit || ($current_email && $has_subscriptions)) : ?>
+                                <a href="<?php echo esc_attr($sub_summary_return_url); ?>">
+                                    <i class="fa fa-arrow-circle-left"></i> <?php echo __('Back to My Subscriptions', SLUG_TD); ?>
+                                </a>
+                            <?php endif; ?>
+                        </p>
                 </div>
 
             <?php endif; ?>
 
                 <h2 style="margin-top:0;">
-                    <a href="<?php echo esc_attr($sub_summary_return_url); ?>" title="<?php echo __('Back to My Subscriptions', SLUG_TD); ?>">
-                        <i class="fa fa-arrow-circle-left pull-right"></i>
-                    </a>
+                    <?php if ($is_edit || ($current_email && $has_subscriptions)) : ?>
+                        <a href="<?php echo esc_attr($sub_summary_return_url); ?>" title="<?php echo __('Back to My Subscriptions', SLUG_TD); ?>">
+                            <i class="fa fa-arrow-circle-left pull-right"></i>
+                        </a>
+                    <?php endif; ?>
                     <?php if ($is_edit) : ?>
                         <?php echo __('Edit Subscription', SLUG_TD); ?>
                     <?php else : // Creating a new subscription. ?>

--- a/src/includes/templates/type-s/site/footer-tag.php
+++ b/src/includes/templates/type-s/site/footer-tag.php
@@ -31,8 +31,8 @@ $home_url = home_url('/'); // Multisite compatible.
 $blog_name_clip = $plugin->utils_string->clip(get_bloginfo('name'));
 
 // Summary return URL; w/ all summary navigation vars preserved.
-$current_email     = (boolean)$this->plugin->utils_sub->currentEmail();
-$has_subscriptions = $current_email ? (boolean)$this->plugin->utils_sub->queryTotal(null, ['sub_email' => $current_email, 'status' => 'subscribed', 'sub_email_or_user_ids' => true]) : false;
+$current_email     = $this->plugin->utils_sub->currentEmail();
+$has_subscriptions = (boolean)$current_email ? (boolean)$this->plugin->utils_sub->queryTotal(null, ['sub_email' => $current_email, 'status' => 'subscribed', 'sub_email_or_user_ids' => true]) : false;
 $sub_summary_return_url = $has_subscriptions && $plugin->utils_url->subManageSummaryUrl(!empty($sub_key) ? $sub_key : '', null, true);
 
 // Current `host[/path]` with support for multisite network child blogs.

--- a/src/includes/templates/type-s/site/footer-tag.php
+++ b/src/includes/templates/type-s/site/footer-tag.php
@@ -31,7 +31,9 @@ $home_url = home_url('/'); // Multisite compatible.
 $blog_name_clip = $plugin->utils_string->clip(get_bloginfo('name'));
 
 // Summary return URL; w/ all summary navigation vars preserved.
-$sub_summary_return_url = $plugin->utils_url->subManageSummaryUrl(!empty($sub_key) ? $sub_key : '', null, true);
+$current_email     = (boolean)$this->plugin->utils_sub->currentEmail();
+$has_subscriptions = $current_email ? (boolean)$this->plugin->utils_sub->queryTotal(null, ['sub_email' => $current_email, 'status' => 'subscribed', 'sub_email_or_user_ids' => true]) : false;
+$sub_summary_return_url = $has_subscriptions && $plugin->utils_url->subManageSummaryUrl(!empty($sub_key) ? $sub_key : '', null, true);
 
 // Current `host[/path]` with support for multisite network child blogs.
 $current_host_path = $plugin->utils_url->currentHostPath();

--- a/src/includes/templates/type-s/site/footer-tag.php
+++ b/src/includes/templates/type-s/site/footer-tag.php
@@ -31,9 +31,9 @@ $home_url = home_url('/'); // Multisite compatible.
 $blog_name_clip = $plugin->utils_string->clip(get_bloginfo('name'));
 
 // Summary return URL; w/ all summary navigation vars preserved.
-$current_email     = $this->plugin->utils_sub->currentEmail();
-$has_subscriptions = (boolean)$current_email ? (boolean)$this->plugin->utils_sub->queryTotal(null, ['sub_email' => $current_email, 'status' => 'subscribed', 'sub_email_or_user_ids' => true]) : false;
-$sub_summary_return_url = $has_subscriptions && $plugin->utils_url->subManageSummaryUrl(!empty($sub_key) ? $sub_key : '', null, true);
+$current_email          = $this->plugin->utils_sub->currentEmail();
+$has_subscriptions      = (boolean) $current_email ? (boolean) $this->plugin->utils_sub->queryTotal(null, ['sub_email' => $current_email, 'status' => 'subscribed', 'sub_email_or_user_ids' => true]) : false;
+$sub_summary_return_url = $has_subscriptions ? $plugin->utils_url->subManageSummaryUrl(!empty($sub_key) ? $sub_key : '', null, true) : false;
 
 // Current `host[/path]` with support for multisite network child blogs.
 $current_host_path = $plugin->utils_url->currentHostPath();

--- a/src/includes/templates/type-s/site/sub-actions/manage-sub-form.php
+++ b/src/includes/templates/type-s/site/sub-actions/manage-sub-form.php
@@ -79,11 +79,13 @@ echo str_replace('%%title%%', $is_edit ? __('Edit Subscription', SLUG_TD)
                         </li>
                     <?php endforeach; ?>
                 </ul>
-                <p style="margin-top:1em;">
-                    <a href="<?php echo esc_attr($plugin->utils_url->subManageSummaryUrl($sub_key, null, true)); ?>">
-                        <i class="fa fa-arrow-circle-left"></i> <?php echo __('Back to My Subscriptions', SLUG_TD); ?>
-                    </a>
-                </p>
+                    <p style="margin-top:1em;">
+                        <?php if ($is_edit || ($current_email && $has_subscriptions)) : ?>
+                            <a href="<?php echo esc_attr($plugin->utils_url->subManageSummaryUrl($sub_key, null, true)); ?>">
+                                <i class="fa fa-arrow-circle-left"></i> <?php echo __('Back to My Subscriptions', SLUG_TD); ?>
+                            </a>
+                        <?php endif; ?>
+                    </p>
             </div>
 
         <?php elseif ($error_codes) : // Any other major errors? ?>
@@ -163,19 +165,23 @@ echo str_replace('%%title%%', $is_edit ? __('Edit Subscription', SLUG_TD)
                             </li>
                         <?php endforeach; ?>
                     </ul>
-                    <p style="margin-top:1em;">
-                        <a href="<?php echo esc_attr($sub_summary_return_url); ?>">
-                            <i class="fa fa-arrow-circle-left"></i> <?php echo __('Back to My Subscriptions', SLUG_TD); ?>
-                        </a>
-                    </p>
+                        <p style="margin-top:1em;">
+                            <?php if ($is_edit || ($current_email && $has_subscriptions)) : ?>
+                                <a href="<?php echo esc_attr($sub_summary_return_url); ?>">
+                                    <i class="fa fa-arrow-circle-left"></i> <?php echo __('Back to My Subscriptions', SLUG_TD); ?>
+                                </a>
+                            <?php endif; ?>
+                        </p>
                 </div>
 
             <?php endif; ?>
 
                 <h2 style="margin-top:0;">
-                    <a href="<?php echo esc_attr($sub_summary_return_url); ?>" title="<?php echo __('Back to My Subscriptions', SLUG_TD); ?>">
-                        <i class="fa fa-arrow-circle-left pull-right"></i>
-                    </a>
+                    <?php if ($is_edit || ($current_email && $has_subscriptions)) : ?>
+                        <a href="<?php echo esc_attr($sub_summary_return_url); ?>" title="<?php echo __('Back to My Subscriptions', SLUG_TD); ?>">
+                            <i class="fa fa-arrow-circle-left pull-right"></i>
+                        </a>
+                    <?php endif; ?>
                     <?php if ($is_edit) : ?>
                         <?php echo __('Edit Subscription', SLUG_TD); ?>
                     <?php else : // Creating a new subscription. ?>


### PR DESCRIPTION
Disable back button when no subscriptions are available; 

- Continuation from this Pull Request: https://github.com/websharks/comment-mail-pro/pull/71
- Tested in the following scenarios:
    - User is not logged in and no Subscription Key is present
    - User is logged in but does not have any subscriptions

See: websharks/comment-mail#229

--------------------------------

**TODO**
- [ ] <del> Display back button and "Manage Subscriptions" link when user is logged in with existing subscriptions. </del>
